### PR TITLE
Add SpotifyClientController and refactor associated calls

### DIFF
--- a/Controllers/SpotifyClientController.cs
+++ b/Controllers/SpotifyClientController.cs
@@ -1,0 +1,42 @@
+﻿using SpotifyAPI.Web;
+
+namespace SpotifyBlazor.Controllers;
+
+public class SpotifyClientController
+{
+    public static bool ActiveDevice;
+    
+    public static bool IsPlaying;
+    
+    public static async Task ChooseDevice(SpotifyClient spotify, Device device)
+    {
+        ActiveDevice = await spotify.Player.TransferPlayback(new PlayerTransferPlaybackRequest(new List<string> { device.Id }));
+    }
+
+    public static async Task Play(SpotifyClient spotify, SimplePlaylist? selectedPlaylist)
+    {
+        await spotify.Player.ResumePlayback(new PlayerResumePlaybackRequest
+        {
+            ContextUri = $"spotify:playlist:{selectedPlaylist.Id}",
+            // OffsetParam = _spotify.Player.GetCurrentlyPlaying(new PlayerCurrentlyPlayingRequest()).Result.Item,
+            PositionMs = spotify.Player.GetCurrentlyPlaying(new PlayerCurrentlyPlayingRequest()).Result.ProgressMs
+        });
+        IsPlaying = true;
+    }
+    
+    public static async Task Pause(SpotifyClient spotify)
+    {
+        await spotify.Player.PausePlayback();
+        IsPlaying = false;
+    }
+
+    public static async Task Next(SpotifyClient spotify)
+    {
+        await spotify.Player.SkipNext();
+    }
+
+    public static async Task Previous(SpotifyClient spotify)
+    {
+        await spotify.Player.SkipPrevious();
+    }
+}

--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -1,5 +1,6 @@
 ﻿@page "/"
 @using SpotifyAPI.Web
+@using SpotifyBlazor.Controllers
 @inject NavigationManager navManager
 
 @* UI to show mixing desk with sliders of parameters to meet e.g. instrumentalness, tempo etc
@@ -10,7 +11,7 @@ App will get all users songs and generate playlist meeting parameters
 
 @if (_isAuthed && _me != null)
 {
-    @if (!_activeDevice)
+    @if (!SpotifyClientController.ActiveDevice)
     {
         <h2>Welcome @_me.DisplayName!</h2>
         <p>
@@ -20,7 +21,7 @@ App will get all users songs and generate playlist meeting parameters
                     @foreach (var device in _devicesList)
                     {
                         <button id=@device.Name>
-                            <a @onclick="() => ChooseDevice(device)">@device.Name</a>
+                            <a @onclick="() => SpotifyClientController.ChooseDevice(_spotify, device)">@device.Name</a>
                         </button>
                     }
                 </ul>
@@ -51,20 +52,22 @@ App will get all users songs and generate playlist meeting parameters
             var totalTracks = $"Total number of tracks: {_selectedPlaylist.Tracks.Total}";
             <p>@totalTracks</p>
 
-            _isPlaying = _spotify.Player.GetCurrentlyPlaying(new PlayerCurrentlyPlayingRequest()).Result.IsPlaying;
+            SpotifyClientController.IsPlaying = _spotify.Player.GetCurrentlyPlaying(new PlayerCurrentlyPlayingRequest()).Result.IsPlaying;
             
-            @if (_isPlaying)
+            <button id="previous" @onclick="() => SpotifyClientController.Previous(_spotify)">Previous</button>
+            
+            @if (SpotifyClientController.IsPlaying)
             {
-                <button id="pause" @onclick="Pause">Pause</button>
+                <button id="pause" @onclick="() => SpotifyClientController.Pause(_spotify)">Pause</button>
             }
-            else if (!_isPlaying)
+            else if (!SpotifyClientController.IsPlaying)
             {
-                <button id="play" @onclick="Play">Play</button>
+                <button id="play" @onclick="() => SpotifyClientController.Play(_spotify, _selectedPlaylist)">Play</button>
             }
-            <button id="skip" @onclick="Skip">Skip</button>
+            <button id="next" @onclick="() => SpotifyClientController.Next(_spotify)">Next</button>
             <button @onclick="GoBackToPlaylists">Back to Playlists</button>
             
-            <p>@_isPlaying</p>
+            <p>@SpotifyClientController.IsPlaying</p>
         }
     }
 }
@@ -83,24 +86,23 @@ else
     private Uri _authUri;
 
     private bool _isAuthed;
-    private SimplePlaylist? _selectedPlaylist;
 
     private PrivateUser _me;
 
+    private Dictionary<string, string>? _fragmentParams;
+    
     private int? _totalPlaylistCount;
 
     private List<SimplePlaylist>? _playlists;
-
-    private Dictionary<string, string>? _fragmentParams;
-
+    
+    private SimplePlaylist? _selectedPlaylist;
+    
     private SpotifyClient _spotify;
 
     private DeviceResponse _devices;
 
     private List<Device> _devicesList;
-
-    private bool _activeDevice;
-
+    
     private bool _isPlaying;
 
     protected override void OnInitialized()
@@ -138,38 +140,13 @@ else
             _devicesList = _devices.Devices;
         }
     }
-
-    public async Task ChooseDevice(Device device)
-    {
-        _activeDevice = await _spotify.Player.TransferPlayback(new PlayerTransferPlaybackRequest(new List<string> { device.Id }));
-    }
-
-    public async Task Play()
-    {
-        await _spotify.Player.ResumePlayback(new PlayerResumePlaybackRequest
-        {
-            ContextUri = $"spotify:playlist:{_selectedPlaylist.Id}",
-            // OffsetParam = _spotify.Player.GetCurrentlyPlaying(new PlayerCurrentlyPlayingRequest()).Result.Item,
-            PositionMs = _spotify.Player.GetCurrentlyPlaying(new PlayerCurrentlyPlayingRequest()).Result.ProgressMs
-        });
-    }
-
-    public async Task Skip()
-    {
-        await _spotify.Player.SkipNext();
-    }
-
-    public async Task Pause()
-    {
-        await _spotify.Player.PausePlayback();
-    }
-
-    public void GetTracksFromPlaylist(SimplePlaylist playlist)
+    
+    private void GetTracksFromPlaylist(SimplePlaylist playlist)
     {
         _selectedPlaylist = playlist;
     }
-
-    public void GoBackToPlaylists()
+    
+    private void GoBackToPlaylists()
     {
         _selectedPlaylist = null;
     }

--- a/Program.cs
+++ b/Program.cs
@@ -1,3 +1,4 @@
+using SpotifyBlazor.Controllers;
 using SpotifyBlazor.Data;
 
 var builder = WebApplication.CreateBuilder(args);


### PR DESCRIPTION
A new SpotifyClientController has been created to handle Spotify client calls such as playing, pausing, and skipping tracks. The associated calls within the application, specifically within Index.razor, have been refactored to use this new controller, enhancing code organization and maintainability.