### PR TITLE
Refactor TrackService to handle large playlists

### DIFF
--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -16,19 +16,27 @@ App will get all users songs and generate playlist meeting parameters
     @if (!SpotifyClientController.ActiveDevice)
     {
         <h2>Welcome @_me.DisplayName!</h2>
-        <p>
-            Please select a device:
-            <div>
-                <ul>
-                    @foreach (var device in _devicesList)
-                    {
-                        <button id=@device.Name>
-                            <a @onclick="() => SpotifyClientController.ChooseDevice(_spotify, device)">@device.Name</a>
-                        </button>
-                    }
-                </ul>
-            </div>
-        </p>
+        if (_devicesList.Count == 0)
+        {
+            <p>Please open the spotify app on a device then refresh page</p>
+        }
+        else
+        {
+
+            <p>
+                Please select a device:
+                <div>
+                    <ul>
+                        @foreach (var device in _devicesList)
+                        {
+                            <button id=@device.Name>
+                                <a @onclick="() => SpotifyClientController.ChooseDevice(_spotify, device)">@device.Name</a>
+                            </button>
+                        }
+                    </ul>
+                </div>
+            </p>
+        }
     }
     else
     {


### PR DESCRIPTION
The previous implementation in TrackService was not equipped to handle playlists with a large number of tracks. This update introduces a chunking mechanism that makes multiple track-fetch requests with a limit of 100 tracks per request, to allow proper handling of large playlists. An AddMatchingTracksToTrackList method has also been introduced to manage the addition of tracks to the playlist. The TrackService class is also made static for better utilization.